### PR TITLE
Configure project for Sonatype deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Keyring
         if: startsWith(github.ref, 'refs/tags/')
-        run: mkdir -p ~/.gnupg && echo "${{ secrets.SIGNING_SECRET_KEY_RING }}" | base64 --decode > ~/.gnupg/secring.gpg
+        run: echo "${{ secrets.SIGNING_SECRET_KEY_RING }}" | base64 --decode > ~/secring.gpg
 
       - name: Publish
         # https://github.community/t5/GitHub-Actions/Run-step-only-for-new-tags/m-p/32448/highlight/true#M1138
@@ -65,4 +65,4 @@ jobs:
           -PVERSION_NAME=${GITHUB_REF/refs\/tags\//}
           -Psigning.keyId="${{ secrets.SIGNING_KEY_ID }}"
           -Psigning.password="${{ secrets.SIGNING_PASSWORD }}"
-          -Psigning.secretKeyRingFile="$HOME/.gnupg/secring.gpg"
+          -Psigning.secretKeyRingFile="$HOME/secring.gpg"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@
 name: CI
 on: push
 
+env:
+  SONATYPE_NEXUS_USERNAME: ${{ secrets.OSS_SONATYPE_NEXUS_USERNAME }}
+  SONATYPE_NEXUS_PASSWORD: ${{ secrets.OSS_SONATYPE_NEXUS_PASSWORD }}
+
 jobs:
   build:
     runs-on: ubuntu-16.04
@@ -16,6 +20,7 @@ jobs:
       GRADLE_ARGS: >-
         --stacktrace
         --no-daemon
+        --no-parallel
         --max-workers 2
         -Pkotlin.incremental=false
 
@@ -36,3 +41,30 @@ jobs:
 
       - name: Check
         run: ./gradlew $GRADLE_ARGS check
+
+      - name: Snapshot
+        if: startsWith(github.ref, 'refs/heads/') && endsWith(github.ref, '-SNAPSHOT')
+        run: >-
+          ./gradlew
+          $GRADLE_ARGS
+          --no-parallel
+          uploadArchives
+          -PVERSION_NAME="${GITHUB_REF/refs\/heads\//}"
+
+      - name: Keyring
+        if: startsWith(github.ref, 'refs/tags/')
+        run: mkdir -p ~/.gnupg && echo "${{ secrets.SIGNING_SECRET_KEY_RING }}" | base64 --decode > ~/.gnupg/secring.gpg
+
+      - name: Publish
+        # https://github.community/t5/GitHub-Actions/Run-step-only-for-new-tags/m-p/32448/highlight/true#M1138
+        if: startsWith(github.ref, 'refs/tags/')
+        # https://github.community/t5/GitHub-Actions/How-to-get-just-the-tag-name/m-p/32167/highlight/true#M1027
+        run: >-
+          ./gradlew
+          $GRADLE_ARGS
+          --no-parallel
+          uploadArchives
+          -PVERSION_NAME=${GITHUB_REF/refs\/tags\//}
+          -Psigning.keyId="${{ secrets.SIGNING_KEY_ID }}"
+          -Psigning.password="${{ secrets.SIGNING_PASSWORD }}"
+          -Psigning.secretKeyRingFile="$HOME/.gnupg/secring.gpg"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,6 @@ jobs:
         run: >-
           ./gradlew
           $GRADLE_ARGS
-          --no-parallel
           uploadArchives
           -PVERSION_NAME="${GITHUB_REF/refs\/heads\//}"
 
@@ -62,7 +61,6 @@ jobs:
         run: >-
           ./gradlew
           $GRADLE_ARGS
-          --no-parallel
           uploadArchives
           -PVERSION_NAME=${GITHUB_REF/refs\/tags\//}
           -Psigning.keyId="${{ secrets.SIGNING_KEY_ID }}"

--- a/README.md
+++ b/README.md
@@ -5,20 +5,18 @@ Exercise makes it possible to pass intent extras easily and correctly.
 
 # Getting started
 
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.juul.exercise/compile/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.juul.exercise/compile)
+
 First, add it to gradle.
 
 ```gradle
-// In your root build.gradle
-allprojects {
-  repositories {
-    maven { url 'https://jitpack.io' }
-  }
+repositories {
+  jcenter() // or mavenCentral()
 }
 
-// In your application build.gradle
 dependencies {
-  implementation "com.github.juullabs-oss.android-exercise:annotations:$version"
-  kapt "com.github.juullabs-oss.android-exercise:compile:$version"
+  implementation "com.juul.exercise:annotations:$version"
+  kapt "com.juul.exercise:compile:$version"
 }
 ```
 

--- a/annotations/build.gradle
+++ b/annotations/build.gradle
@@ -1,9 +1,9 @@
 apply plugin: 'java-library'
 apply plugin: 'kotlin'
-apply plugin: 'maven-publish'
+apply plugin: "com.vanniktech.maven.publish"
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }
 
 sourceCompatibility = "1.8"
@@ -18,14 +18,5 @@ compileKotlin {
 compileTestKotlin {
     kotlinOptions {
         jvmTarget = "1.8"
-    }
-}
-
-publishing {
-    publications {
-        maven(MavenPublication) {
-            artifactId = 'annotations'
-            from components.java
-        }
     }
 }

--- a/annotations/gradle.properties
+++ b/annotations/gradle.properties
@@ -1,0 +1,1 @@
+POM_ARTIFACT_ID=annotations

--- a/build.gradle
+++ b/build.gradle
@@ -1,16 +1,15 @@
-// Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = "1.3.70"
+    ext.kotlin_version = "1.3.72"
+
     repositories {
         google()
         jcenter()
     }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.0-rc01'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle files
+    dependencies {
+        classpath 'com.android.tools.build:gradle:4.0.0'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath 'com.vanniktech:gradle-maven-publish-plugin:0.11.1'
     }
 }
 
@@ -19,12 +18,6 @@ allprojects {
         google()
         jcenter()
     }
-}
-
-subprojects {
-    // group = 'com.juullabs.exercise'
-    group = 'com.github.juullabs-oss.android-exercise'
-    version = '0.6.1'
 }
 
 task clean(type: Delete) {

--- a/compile/build.gradle
+++ b/compile/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'java-library'
 apply plugin: 'kotlin'
-apply plugin: 'maven-publish'
+apply plugin: "com.vanniktech.maven.publish"
 
 dependencies {
     if (JavaVersion.current() == JavaVersion.VERSION_1_8) {
@@ -8,7 +8,7 @@ dependencies {
     }
     implementation project(":annotations")
     implementation "com.squareup:kotlinpoet:1.5.0"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }
 
 sourceCompatibility = "1.8"
@@ -24,14 +24,5 @@ compileKotlin {
 compileTestKotlin {
     kotlinOptions {
         jvmTarget = "1.8"
-    }
-}
-
-publishing {
-    publications {
-        maven(MavenPublication) {
-            artifactId = 'compile'
-            from components.java
-        }
     }
 }

--- a/compile/gradle.properties
+++ b/compile/gradle.properties
@@ -1,0 +1,1 @@
+POM_ARTIFACT_ID=compile

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,3 +19,23 @@ android.useAndroidX=true
 android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
+
+GROUP=com.juul.exercise
+POM_ARTIFACT_ID=exercise
+VERSION_NAME=unspecified-SNAPSHOT
+
+POM_NAME=Exercise
+POM_DESCRIPTION=Exercise is an annotation processor for Kotlin Android projects. Exercise makes it possible to pass intent extras easily and correctly.
+
+POM_URL=https://github.com/JuulLabs/android-exercise
+POM_SCM_URL=https://github.com/JuulLabs/android-exercise
+POM_SCM_CONNECTION=scm:git:git://github.com/JuulLabs/android-exercise.git
+POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/JuulLabs/android-exercise.git
+
+POM_LICENSE_NAME=The Apache Software License, Version 2.0
+POM_LICENSE_URL=http://www.apache.org/licenses/LICENSE-2.0.txt
+POM_LICENSE_DIST=repo
+
+POM_DEVELOPER_ID=cedrickcooke
+POM_DEVELOPER_NAME=Cedrick Cooke
+POM_DEVELOPER_URL=https://github.com/cedrickcooke

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,8 +21,6 @@ android.enableJetifier=true
 kotlin.code.style=official
 
 GROUP=com.juul.exercise
-POM_ARTIFACT_ID=exercise
-VERSION_NAME=unspecified-SNAPSHOT
 
 POM_NAME=Exercise
 POM_DESCRIPTION=Exercise is an annotation processor for Kotlin Android projects. Exercise makes it possible to pass intent extras easily and correctly.

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,6 +21,7 @@ android.enableJetifier=true
 kotlin.code.style=official
 
 GROUP=com.juul.exercise
+VERSION_NAME=unspecified
 
 POM_NAME=Exercise
 POM_DESCRIPTION=Exercise is an annotation processor for Kotlin Android projects. Exercise makes it possible to pass intent extras easily and correctly.


### PR DESCRIPTION
- Deploy snapshots via git branches suffixed with `-SNAPSHOT`
    - Once deployed, you should be able to see them at https://oss.sonatype.org/content/repositories/snapshots/com/juul/exercise/
- Push to Sonatype via git tags
    - We can [promote to Maven central](https://youtu.be/dXR4pJ_zS-0?t=239) via https://oss.sonatype.org/#welcome
        - Let me know if you want the credentials, otherwise I can do it upon request

Library consumers can use the snapshots via:

```groovy
repositories {
    maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
}

dependencies {
    implementation "com.juul.exercise:annotations:$version"
    kapt "com.juul.exercise:compile:$version"
}
```